### PR TITLE
StepCollector - isolate try catch on InputStream conversion to byte[]

### DIFF
--- a/dil/src/main/java/org/assimbly/dil/event/collect/StepCollector.java
+++ b/dil/src/main/java/org/assimbly/dil/event/collect/StepCollector.java
@@ -98,53 +98,56 @@ public class StepCollector extends EventNotifierSupport {
 
     private void processEvent(Exchange exchange, String stepId, long stepTimestamp){
 
-        try {
-            // read body only once
-            InputStream inputStream = exchange.getMessage().getBody(InputStream.class);
-            byte[] body = IOUtils.toByteArray(inputStream);
-            int bodyLength = body != null ? body.length : 0;
-            String bodyType = body != null ? exchange.getMessage().getBody().getClass().getSimpleName() : "";
+        // read body only once
+        InputStream inputStream = exchange.getMessage().getBody(InputStream.class);
 
-            // set custom properties
-            setCustomProperties(exchange, bodyType, bodyLength, stepId, stepTimestamp);
-
-            //set fields
-            Message message = exchange.getMessage();
-            String bodyToStoreOnEvent = getBodyToStoreOnEvent(exchange, body);
-            Map<String, Object> headers = message.getHeaders();
-            Map<String, Object> properties = exchange.getProperties();
-            String transactionId = message.getMessageId();
-
-            //use breadcrumbId when available, otherwise set custom
-            transactionId = message.getHeader(BREADCRUMB_ID_HEADER, String.class);
-            if (transactionId == null || transactionId.isEmpty()) {
-                transactionId = message.getMessageId() + "_" + stepId;
-                message.setHeader(BREADCRUMB_ID_HEADER, transactionId);
-            }
-
-            // get previous flowId and flowVersion
-            String previousFlowId = exchange.getMessage().getHeader(FLOW_ID_HEADER, String.class);
-            String previousFlowVersion = exchange.getMessage().getHeader(FLOW_VERSION_HEADER, String.class);
-            // set flowId and flowVersion
-            exchange.getMessage().setHeader(FLOW_ID_HEADER, flowId);
-            exchange.getMessage().setHeader(FLOW_VERSION_HEADER, flowVersion);
-
-            //calculate times
-            String timestamp = EventUtil.getCreatedTimestamp(stepTimestamp);
-            String expiryDate = EventUtil.getExpiryTimestamp(expiryInHours);
-
-            //create json
-            MessageEvent messageEvent = new MessageEvent(
-                    timestamp, transactionId, flowId, flowVersion, previousFlowId, previousFlowVersion, stepId, headers,
-                    properties, bodyToStoreOnEvent, expiryDate
-            );
-            String json = messageEvent.toJson();
-
-            //store the event
-            storeManager.storeEvent(json);
-        } catch (Exception e) {
-            log.error("Error to process event", e);
+        byte[] body = null;
+        if (inputStream != null) {
+            try {
+                body = IOUtils.toByteArray(inputStream);
+            } catch (Exception e) { }
         }
+
+        int bodyLength = body != null ? body.length : 0;
+        String bodyType = body != null ? exchange.getMessage().getBody().getClass().getSimpleName() : "";
+
+        // set custom properties
+        setCustomProperties(exchange, bodyType, bodyLength, stepId, stepTimestamp);
+
+        //set fields
+        Message message = exchange.getMessage();
+        String bodyToStoreOnEvent = getBodyToStoreOnEvent(exchange, body);
+        Map<String, Object> headers = message.getHeaders();
+        Map<String, Object> properties = exchange.getProperties();
+        String transactionId = message.getMessageId();
+
+        //use breadcrumbId when available, otherwise set custom
+        transactionId = message.getHeader(BREADCRUMB_ID_HEADER, String.class);
+        if (transactionId == null || transactionId.isEmpty()) {
+            transactionId = message.getMessageId() + "_" + stepId;
+            message.setHeader(BREADCRUMB_ID_HEADER, transactionId);
+        }
+
+        // get previous flowId and flowVersion
+        String previousFlowId = exchange.getMessage().getHeader(FLOW_ID_HEADER, String.class);
+        String previousFlowVersion = exchange.getMessage().getHeader(FLOW_VERSION_HEADER, String.class);
+        // set flowId and flowVersion
+        exchange.getMessage().setHeader(FLOW_ID_HEADER, flowId);
+        exchange.getMessage().setHeader(FLOW_VERSION_HEADER, flowVersion);
+
+        //calculate times
+        String timestamp = EventUtil.getCreatedTimestamp(stepTimestamp);
+        String expiryDate = EventUtil.getExpiryTimestamp(expiryInHours);
+
+        //create json
+        MessageEvent messageEvent = new MessageEvent(
+                timestamp, transactionId, flowId, flowVersion, previousFlowId, previousFlowVersion, stepId, headers,
+                properties, bodyToStoreOnEvent, expiryDate
+        );
+        String json = messageEvent.toJson();
+
+        //store the event
+        storeManager.storeEvent(json);
     }
 
     public String getBodyToStoreOnEvent(Exchange exchange, byte[] body) {


### PR DESCRIPTION
use try catch only when converts InputStream into a byte[], this way ……it will continue even when conversion is not possible, and uses an empty body