### PR TITLE
ZipFileEnrichStrategy - PoolEnrich - if newExchange is null, it means there's no remote file to consume

### DIFF
--- a/dil/src/main/java/org/assimbly/dil/blocks/beans/enrich/zipfile/ZipFileEnrichStrategy.java
+++ b/dil/src/main/java/org/assimbly/dil/blocks/beans/enrich/zipfile/ZipFileEnrichStrategy.java
@@ -27,6 +27,11 @@ public class ZipFileEnrichStrategy implements AggregationStrategy {
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
         elementNames = new ArrayList<>();
 
+        if (newExchange == null) {
+            // there’s no remote file to consume
+            return oldExchange;
+        }
+
         Message in = oldExchange.getIn();
         Message resource = newExchange.getIn();
 

--- a/dil/src/main/java/org/assimbly/dil/blocks/beans/enrich/zipfile/ZipFileEnrichStrategy.java
+++ b/dil/src/main/java/org/assimbly/dil/blocks/beans/enrich/zipfile/ZipFileEnrichStrategy.java
@@ -38,7 +38,7 @@ public class ZipFileEnrichStrategy implements AggregationStrategy {
         byte[] sourceZip = in.getBody(byte[].class);
         byte[] resourceData = resource.getBody(byte[].class);
 
-        String fileName = resource.getHeader(Exchange.FILE_NAME, String.class);
+        String fileName = resource.getHeader(Exchange.FILE_NAME_CONSUMED, String.class);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/dil/src/main/java/org/assimbly/dil/blocks/beans/enrich/zipfile/ZipFileEnrichStrategy.java
+++ b/dil/src/main/java/org/assimbly/dil/blocks/beans/enrich/zipfile/ZipFileEnrichStrategy.java
@@ -36,7 +36,7 @@ public class ZipFileEnrichStrategy implements AggregationStrategy {
         Message resource = newExchange.getIn();
 
         byte[] sourceZip = in.getBody(byte[].class);
-        byte[] resourceData = resource.getBody(byte[].class);
+        byte[] resourceData = newExchange.getContext().getTypeConverter().convertTo(byte[].class, resource.getBody());
 
         String fileName = resource.getHeader(Exchange.FILE_NAME_CONSUMED, String.class);
 


### PR DESCRIPTION
> First, you check whether any data was consumed. If newExchange is null, there’s no remote file to consume, and you just return the existing data.

https://livebook.manning.com/book/camel-in-action-second-edition/chapter-3/117