### PR TITLE
TestContainers unit tests - changes/fixes

### DIFF
--- a/commons/src/main/java/org/assimbly/commons/utils/AssertUtils.java
+++ b/commons/src/main/java/org/assimbly/commons/utils/AssertUtils.java
@@ -236,7 +236,6 @@ public final class AssertUtils {
         assertThat(flowJson.get("lastCompleted")).isNotNull();
         assertThat(flowJson.get("id")).isNotNull();
         assertThat(flowJson.get(STATUS).asText()).isEqualTo(status);
-        assertCpuLoadStatsResponse(flowJson);
     }
 
     public static void assertCpuLoadStatsResponse(JsonNode responseJson) {

--- a/integrationRest/src/test/java/org/assimbly/integrationrest/CertificateManagerRuntimeTest.java
+++ b/integrationRest/src/test/java/org/assimbly/integrationrest/CertificateManagerRuntimeTest.java
@@ -34,7 +34,7 @@ class CertificateManagerRuntimeTest {
     static void tearDown() {
         container.stop();
     }
-
+/*
     @Test
     @Order(1)
     @Disabled("to be tested on future releases")
@@ -63,7 +63,7 @@ class CertificateManagerRuntimeTest {
             fail("Test failed due to unexpected exception: " + e.getMessage(), e);
         }
     }
-
+*/
     @Test
     @Order(2)
     void shouldUploadCertificate() {


### PR DESCRIPTION
- **StatisticsRuntime**
  - `/api/integration/stats/flows` - cpuLoadLastMinute data is no longer returned on response
  - `/api/integration/statsbyflowids` - cpuLoadLastMinute data is no longer returned on response

- **CertificateManagerRuntime**
  - `/api/certificates/generate` - removed/commented disabled unit test